### PR TITLE
Recognize new template parameter declaration syntax.

### DIFF
--- a/Syntaxes/Soy.YAML-tmLanguage
+++ b/Syntaxes/Soy.YAML-tmLanguage
@@ -89,10 +89,7 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.comment.end.soy}
     patterns:
-    - match: (@param|@param\?)\s+(\w+)
-      captures:
-        '1': {name: support.type.soy}
-        '2': {name: variable.parameter.soy}
+    - include: '#template-param'
 
   comment-line:
     name: comment.line.double-slash.soy
@@ -393,6 +390,7 @@ repository:
     - include: '#number'
     - include: '#primitive'
     - include: '#print-parameter'
+    - include: '#template-param'
 
   tag-simple:
     name: entity.name.tag.soy
@@ -431,6 +429,13 @@ repository:
         '1': {name: entity.other.attribute-name.soy}
         '2': {name: keyword.operator.soy}
         '3': {name: string.quoted.single.soy}
+
+  template-param:
+    name: meta.tag.template.param.soy
+    match: (@param|@param\?)\s+(\w+)
+    captures:
+      '1': {name: support.type.soy}
+      '2': {name: variable.parameter.soy}
 
   variable:
     name: variable.other.soy

--- a/Syntaxes/Soy.tmLanguage
+++ b/Syntaxes/Soy.tmLanguage
@@ -235,21 +235,8 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>support.type.soy</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.parameter.soy</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(@param|@param\?)\s+(\w+)</string>
+					<key>include</key>
+					<string>#template-param</string>
 				</dict>
 			</array>
 		</dict>
@@ -1158,6 +1145,10 @@
 					<key>include</key>
 					<string>#print-parameter</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#template-param</string>
+				</dict>
 			</array>
 		</dict>
 		<key>tag-simple</key>
@@ -1299,6 +1290,26 @@
 					<string>\b(autoescape)\s*(=)\s*('true'|'false'|'contextual')</string>
 				</dict>
 			</array>
+		</dict>
+		<key>template-param</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.type.soy</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.soy</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(@param|@param\?)\s+(\w+)</string>
+			<key>name</key>
+			<string>meta.tag.template.param.soy</string>
 		</dict>
 		<key>variable</key>
 		<dict>


### PR DESCRIPTION
Documentation for the new syntax is [here](https://developers.google.com/closure/templates/docs/commands#param).

I just started working on Sublime syntaxes, so apologies if I'm doing something wrong.